### PR TITLE
chore(nix): manage neovim via home-manager programs module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -143,6 +143,7 @@
             (import ./nix/modules/home-manager/tools-read.nix { inherit pkgs; })
             ./nix/modules/linux/system.nix
             ./nix/modules/home-manager/dotfiles-link.nix
+            ./nix/modules/home-manager/program/nvim/default.nix
             agent-skills-nix.homeManagerModules.default
             ./nix/modules/home-manager/agent-skills.nix
           ];
@@ -163,6 +164,7 @@
             (import ./nix/modules/home-manager/tools-read-wsl.nix { inherit pkgs; })
             ./nix/modules/wsl/system.nix
             ./nix/modules/home-manager/dotfiles-link.nix
+            ./nix/modules/home-manager/program/nvim/default.nix
             agent-skills-nix.homeManagerModules.default
             ./nix/modules/home-manager/agent-skills.nix
           ];
@@ -339,6 +341,7 @@
                   })
                   ./nix/modules/home-manager/darwin.nix
                   ./nix/modules/home-manager/dotfiles-link.nix
+                  ./nix/modules/home-manager/program/nvim/default.nix
                   agent-skills-nix.homeManagerModules.default
                   ./nix/modules/home-manager/agent-skills.nix
                 ];

--- a/nix/modules/home-manager/dotfiles-link.nix
+++ b/nix/modules/home-manager/dotfiles-link.nix
@@ -1,14 +1,12 @@
 { config, ... }:
 
 let
-  homeDir = config.home.homeDirectory;
-  dotfilesDir = "${homeDir}/ghq/github.com/nazozokc/dotfiles";
+  dotfilesDir = "${config.home.homeDirectory}/ghq/github.com/nazozokc/dotfiles";
   link = config.lib.file.mkOutOfStoreSymlink;
 in
 {
   home.file = {
     "commitlint.config.js".source = link "${dotfilesDir}/commitlint.config.js";
-    ".config/nvim".source = link "${dotfilesDir}/nvim";
     ".config/fish".source = link "${dotfilesDir}/fish";
     ".config/wezterm".source = link "${dotfilesDir}/wezterm";
     ".config/ghostty".source = link "${dotfilesDir}/ghostty";

--- a/nix/modules/home-manager/packages/base.nix
+++ b/nix/modules/home-manager/packages/base.nix
@@ -2,9 +2,6 @@
 
 with pkgs;
 [
-  # Editor
-  neovim
-
   # shell
   fish
   zsh

--- a/nix/modules/home-manager/packages/dev.nix
+++ b/nix/modules/home-manager/packages/dev.nix
@@ -50,9 +50,9 @@ with pkgs;
 
   # playwright
   playwright-driver
-  chromium
 ]
-++ lib.optionals pkgs.stdenv.isLinux [
+++ pkgs.lib.optionals pkgs.stdenv.isLinux [
   # front end tools
   vite
+  chromium
 ]

--- a/nix/modules/home-manager/program/nvim/default.nix
+++ b/nix/modules/home-manager/program/nvim/default.nix
@@ -1,0 +1,65 @@
+{
+  pkgs,
+  config,
+  ...
+}:
+let
+  dotfilesDir = "${config.home.homeDirectory}/ghq/github.com/nazozokc/dotfiles";
+  nvimDotfilesDir = "${dotfilesDir}/nvim";
+
+  treesitterGrammars = pkgs.vimPlugins.nvim-treesitter.withAllGrammars;
+in
+{
+  programs.neovim = {
+    enable = true;
+
+    withRuby = true;
+    withPython3 = true;
+
+    # Set environment variables only for Neovim session
+    extraWrapperArgs = [
+      "--set"
+      "TREESITTER_GRAMMARS"
+      "${treesitterGrammars}"
+    ];
+
+    # These packages are only available when NeoVim is running
+    extraPackages = with pkgs; [
+      # Plugin build dependencies (lazy.nvim build steps)
+      cmake
+      gcc
+
+      # Language servers
+      lua-language-server
+      nixd
+      efm-langserver
+      pyright
+      typos-lsp
+      typescript-language-server
+
+      # Python tools
+      ruff
+
+      # Formatters & Linters (used by efm-langserver)
+      stylua
+      hadolint
+      actionlint
+
+      # Node.js-based language servers
+      astro-language-server
+      emmet-language-server
+      prisma-language-server
+      stylelint
+      stylelint-lsp
+      svelte-language-server
+      tailwindcss-language-server
+      textlint
+      vscode-langservers-extracted
+      vue-language-server
+      yaml-language-server
+    ];
+  };
+
+  # dotfilesリポジトリのnvim/を~/.config/nvimにsymlink
+  home.file.".config/nvim".source = config.lib.file.mkOutOfStoreSymlink nvimDotfilesDir;
+}


### PR DESCRIPTION
## Summary

- NixでneovimのLSP・formatter・linterを管理するようにした
- `nix/modules/home-manager/program/nvim/default.nix` を新規作成
  - `programs.neovim.enable = true` でneovimをインストール
  - `extraPackages` でLSP・formatter・ビルド依存を宣言
  - `home.file` でdotfilesリポジトリのnvim/をsymlink
- `packages/base.nix` から `neovim` を削除（programs.neovimで管理）
- `dotfiles-link.nix` から `.config/nvim` のsymlink行を削除
- Linux/WSL/Darwinの3つのhome-manager構成に新モジュールをimport追加

## Related Issue

<!-- Issue number if applicable -->

## Screenshots (if applicable)

<!-- Screenshots for UI changes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Neovim configuration with Tree-sitter grammar support for improved syntax highlighting and code navigation
  * Integrated language servers, formatters, and linters for comprehensive development environment support

* **Refactor**
  * Restructured Neovim setup into a dedicated configuration module for improved organization and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nazozokc/dotfiles/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->