### PR TITLE
refactor(nix): symlink opencode rules and output-style to dotfiles repo

### DIFF
--- a/nix/modules/home-manager/program/opencode/default.nix
+++ b/nix/modules/home-manager/program/opencode/default.nix
@@ -1,228 +1,233 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  dotfilesDir,
+  ...
+}:
 
 let
   homeDir = config.home.homeDirectory;
-  dotfilesDir = "${homeDir}/ghq/github.com/nazozokc/dotfiles";
+  link = config.lib.file.mkOutOfStoreSymlink;
 in
 {
-  home.file = {
-    ".config/opencode/opencode.json" = {
-      text = builtins.toJSON {
-        "\$schema" = "https://opencode.ai/config.json";
+  xdg.configFile = {
+    "opencode/opencode.json".text = builtins.toJSON {
+      "\$schema" = "https://opencode.ai/config.json";
 
-        shell = "${pkgs.fish}/bin/fish";
+      shell = "${pkgs.fish}/bin/fish";
 
-        default_agent = "build";
+      default_agent = "build";
 
-        permission = {
-          read = "allow";
-          edit = "allow";
-          glob = "allow";
-          grep = "allow";
-          list = "allow";
-          bash = "ask";
-          task = "ask";
-          webfetch = "allow";
-          websearch = "allow";
-          skill = "allow";
-          todowrite = "allow";
-          question = "ask";
-          lsp = "allow";
+      permission = {
+        read = "allow";
+        edit = "allow";
+        glob = "allow";
+        grep = "allow";
+        list = "allow";
+        bash = "ask";
+        task = "ask";
+        webfetch = "allow";
+        websearch = "allow";
+        skill = "allow";
+        todowrite = "allow";
+        question = "ask";
+        lsp = "allow";
+      };
+
+      agent = {
+        build = {
+          steps = 20;
+          prompt = "You are a build agent. Focus on implementing features, fixing bugs, and writing code. Follow existing patterns and conventions.";
         };
-
-        agent = {
-          build = {
-            steps = 20;
-            prompt = "You are a build agent. Focus on implementing features, fixing bugs, and writing code. Follow existing patterns and conventions.";
-          };
-          plan = {
-            temperature = 0.3;
-            steps = 10;
-            prompt = "You are a planning agent. Focus on architecture, design, and creating detailed implementation plans. Think before acting.";
-          };
-          explore = {
-            steps = 15;
-            prompt = "You are an exploration agent. Focus on understanding the codebase, finding patterns, and gathering context.";
-          };
-          scout = {
-            steps = 10;
-            prompt = "You are a scout agent. Focus on quick information gathering and answering questions about the codebase.";
-          };
-          title = {
-            steps = 1;
-          };
-          summary = {
-            steps = 1;
-          };
-          compaction = {
-            steps = 1;
-          };
+        plan = {
+          temperature = 0.3;
+          steps = 10;
+          prompt = "You are a planning agent. Focus on architecture, design, and creating detailed implementation plans. Think before acting.";
         };
-
-        lsp = {
-          nix = {
-            command = [ "${pkgs.nixd}/bin/nixd" ];
-            extensions = [ "nix" ];
-          };
-          lua = {
-            command = [ "${pkgs.lua-language-server}/bin/lua-language-server" ];
-            extensions = [ "lua" ];
-          };
-          typescript = {
-            command = [
-              "${pkgs.typescript-language-server}/bin/typescript-language-server"
-              "--stdio"
-            ];
-            extensions = [
-              "ts"
-              "tsx"
-              "js"
-              "jsx"
-              "mjs"
-              "cjs"
-            ];
-          };
-          rust = {
-            command = [ "${pkgs.rust-analyzer}/bin/rust-analyzer" ];
-            extensions = [ "rs" ];
-          };
-          go = {
-            command = [ "${pkgs.gopls}/bin/gopls" ];
-            extensions = [ "go" ];
-          };
-          c = {
-            command = [ "${pkgs.clang-tools}/bin/clangd" ];
-            extensions = [
-              "c"
-              "h"
-            ];
-          };
+        explore = {
+          steps = 15;
+          prompt = "You are an exploration agent. Focus on understanding the codebase, finding patterns, and gathering context.";
         };
-
-        formatter = {
-          nix = {
-            command = [ "${pkgs.nixfmt}/bin/nixfmt" ];
-            extensions = [ "nix" ];
-          };
-          lua = {
-            command = [
-              "${pkgs.stylua}/bin/stylua"
-              "-"
-            ];
-            extensions = [ "lua" ];
-          };
-          typescript = {
-            command = [
-              "${pkgs.prettier}/bin/prettier"
-              "--stdin-filepath"
-            ];
-            extensions = [
-              "ts"
-              "tsx"
-              "js"
-              "jsx"
-              "mjs"
-              "cjs"
-              "css"
-              "json"
-              "md"
-              "yaml"
-              "yml"
-            ];
-          };
-          rust = {
-            command = [ "${pkgs.rustfmt}/bin/rustfmt" ];
-            extensions = [ "rs" ];
-          };
+        scout = {
+          steps = 10;
+          prompt = "You are a scout agent. Focus on quick information gathering and answering questions about the codebase.";
         };
-
-        mcp = {
-          context7 = {
-            type = "local";
-            command = [
-              "${pkgs.bun}/bin/bunx"
-              "-y"
-              "@upstash/context7-mcp"
-            ];
-            enabled = true;
-          };
-          playwright = {
-            type = "local";
-            command = [
-              "${pkgs.playwright-mcp}/bin/playwright-mcp"
-              "--browser"
-              "chromium"
-              "--no-sandbox"
-            ];
-            env = {
-              PWMCP_PROFILES_DIR_FOR_TEST = "${homeDir}/.local/share/playwright-mcp/profiles";
-            };
-            enabled = true;
-          };
+        title = {
+          steps = 1;
         };
-
-        instructions = [
-          "${dotfilesDir}/opencode/rules/*.md"
-          "${dotfilesDir}/opencode/output-style/*.md"
-        ];
-
-        skills = {
-          paths = [
-            "${dotfilesDir}/opencode/skills"
-          ];
+        summary = {
+          steps = 1;
         };
-
-        reference = {
-          dotfiles = {
-            repository = "github:nazozokc/dotfiles";
-          };
-        };
-
         compaction = {
-          auto = true;
-          prune = true;
-          tail_turns = 2;
-          reserved = 4096;
+          steps = 1;
         };
+      };
 
-        tool_output = {
-          max_lines = 2000;
-          max_bytes = 51200;
+      lsp = {
+        nix = {
+          command = [ "${pkgs.nixd}/bin/nixd" ];
+          extensions = [ "nix" ];
         };
-
-        watcher = {
-          ignore = [
-            ".git/**"
-            "result/**"
-            "result-*"
-            ".direnv/**"
-            ".venv/**"
-            "__pycache__/**"
-            "*.pyc"
-            ".cache/**"
+        lua = {
+          command = [ "${pkgs.lua-language-server}/bin/lua-language-server" ];
+          extensions = [ "lua" ];
+        };
+        typescript = {
+          command = [
+            "${pkgs.typescript-language-server}/bin/typescript-language-server"
+            "--stdio"
+          ];
+          extensions = [
+            "ts"
+            "tsx"
+            "js"
+            "jsx"
+            "mjs"
+            "cjs"
           ];
         };
+        rust = {
+          command = [ "${pkgs.rust-analyzer}/bin/rust-analyzer" ];
+          extensions = [ "rs" ];
+        };
+        go = {
+          command = [ "${pkgs.gopls}/bin/gopls" ];
+          extensions = [ "go" ];
+        };
+        c = {
+          command = [ "${pkgs.clang-tools}/bin/clangd" ];
+          extensions = [
+            "c"
+            "h"
+          ];
+        };
+      };
 
-        autoupdate = "notify";
+      formatter = {
+        nix = {
+          command = [ "${pkgs.nixfmt}/bin/nixfmt" ];
+          extensions = [ "nix" ];
+        };
+        lua = {
+          command = [
+            "${pkgs.stylua}/bin/stylua"
+            "-"
+          ];
+          extensions = [ "lua" ];
+        };
+        typescript = {
+          command = [
+            "${pkgs.prettier}/bin/prettier"
+            "--stdin-filepath"
+          ];
+          extensions = [
+            "ts"
+            "tsx"
+            "js"
+            "jsx"
+            "mjs"
+            "cjs"
+            "css"
+            "json"
+            "md"
+            "yaml"
+            "yml"
+          ];
+        };
+        rust = {
+          command = [ "${pkgs.rustfmt}/bin/rustfmt" ];
+          extensions = [ "rs" ];
+        };
+      };
 
-        snapshot = true;
-
-        attachment = {
-          image = {
-            auto_resize = true;
-            max_width = 2000;
-            max_height = 2000;
-            max_base64_bytes = 5242880;
+      mcp = {
+        context7 = {
+          type = "local";
+          command = [
+            "${pkgs.bun}/bin/bunx"
+            "-y"
+            "@upstash/context7-mcp"
+          ];
+          enabled = true;
+        };
+        playwright = {
+          type = "local";
+          command = [
+            "${pkgs.playwright-mcp}/bin/playwright-mcp"
+            "--browser"
+            "chromium"
+            "--no-sandbox"
+          ];
+          env = {
+            PWMCP_PROFILES_DIR_FOR_TEST = "${homeDir}/.local/share/playwright-mcp/profiles";
           };
+          enabled = true;
+        };
+      };
+
+      instructions = [
+        "${dotfilesDir}/opencode/rules/*.md"
+        "${dotfilesDir}/opencode/output-style/*.md"
+      ];
+
+      skills = {
+        paths = [
+          "${dotfilesDir}/opencode/skills"
+        ];
+      };
+
+      reference = {
+        dotfiles = {
+          repository = "github:nazozokc/dotfiles";
+        };
+      };
+
+      compaction = {
+        auto = true;
+        prune = true;
+        tail_turns = 2;
+        reserved = 4096;
+      };
+
+      tool_output = {
+        max_lines = 2000;
+        max_bytes = 51200;
+      };
+
+      watcher = {
+        ignore = [
+          ".git/**"
+          "result/**"
+          "result-*"
+          ".direnv/**"
+          ".venv/**"
+          "__pycache__/**"
+          "*.pyc"
+          ".cache/**"
+        ];
+      };
+
+      autoupdate = "notify";
+
+      snapshot = true;
+
+      attachment = {
+        image = {
+          auto_resize = true;
+          max_width = 2000;
+          max_height = 2000;
+          max_base64_bytes = 5242880;
         };
       };
     };
 
-    ".config/opencode/tui.json" = {
-      text = builtins.toJSON {
-        "\$schema" = "https://opencode.ai/tui.json";
-        theme = "kanagawa";
-      };
+    "opencode/tui.json".text = builtins.toJSON {
+      "\$schema" = "https://opencode.ai/tui.json";
+      theme = "kanagawa";
     };
+
+    "opencode/rules".source = link "${dotfilesDir}/opencode/rules";
+    "opencode/output-style".source = link "${dotfilesDir}/opencode/output-style";
+    "opencode/AGENTS.md".source = link "${dotfilesDir}/opencode/AGENTS.md";
   };
 }

--- a/opencode/AGENTS.md
+++ b/opencode/AGENTS.md
@@ -1,0 +1,39 @@
+# opencode 設定 — ユーザーメモリ
+
+## 基本情報
+
+- **ユーザー**: `nazozokc`
+- **リポジトリ**: <https://github.com/nazozokc/dotfiles>
+- **管理方法**: Nix
+
+## このディレクトリの役割
+
+`opencode/`はOpenCodeの設定を管理するディレクトリ。
+
+- `rules/` — コーディング規約・行動規範
+- `output-style/` — 出力スタイル（キャラクター口調など）
+- `AGENTS.md` — このファイル（ユーザーメモリ）
+
+## ユーザー思想
+
+- コードはシンプルだけど多機能
+- どの環境でも再現可能
+- かっこいいほうが好き
+- CLIから抜けたくない
+
+## 回答スタイル
+
+- 挨拶・前置き不要
+- 結論と実行方法を簡潔に
+- 物事にはっきり言う
+- **ついでに**はしない
+
+## 参考レポジトリ
+
+- **一番参照** <https://github.com/ryoppippi/dotfiles>
+- **まあまあ参照** <https://github.com/mozumasu/dotfiles>
+- **構成検討に参考** <https://github.com/ntsk/dotfiles>
+
+## 親AGENTS.md
+
+より詳細な情報はルートの `../../AGENTS.md` を参照。


### PR DESCRIPTION
## Summary
- `program/opencode/default.nix`を `xdg.configFile` + `mkOutOfStoreSymlink` 方式にリファクタ
- `rules/` `output-style/` `AGENTS.md` をリポジトリに直接シンボリックリンク
- `opencode.json` `tui.json` は `builtins.toJSON` でNix管理を維持（`${pkgs.*}` パス参照を保持）
- `opencode/AGENTS.md` を新規作成（ユーザーメモリ）

## Benefits
- JSONはNixで一元管理（パッケージパスを安全に解決）
- 編集頻度の高いrules/output-styleはリポジトリ直結で即反映
- 環境ごとにハードコードされていた`dotfilesDir` を `dotfilesDir` 引数に統一