### PR TITLE
feat: enhance ollama config with service, oterm, and fish abbrs

### DIFF
--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -81,5 +81,12 @@ end
 abbr --add df df\ -h
 abbr --add du du\ -h
 
+# Ollama
+abbr --add o ollama
+abbr --add ol 'ollama list'
+abbr --add ops 'ollama ps'
+abbr --add or 'ollama run'
+abbr --add op 'ollama pull'
+
 # nix
 abbr --add ns nix-shell

--- a/nix/modules/home-manager/program/ollama/default.nix
+++ b/nix/modules/home-manager/program/ollama/default.nix
@@ -1,7 +1,18 @@
-{ pkgs, ... }:
-
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  services.ollama = {
+    enable = true;
+    # acceleration = null;  # null: デフォルト, "cuda": NVIDIA, "rocm": AMD
+    host = "127.0.0.1";
+    port = 11434;
+  };
+
   home.packages = with pkgs; [
-    ollama
+    oterm
   ];
 }


### PR DESCRIPTION
## 変更内容

### nix/modules/home-manager/program/ollama/default.nix
- `services.ollama.enable = true` でsystemd/launchdサービスとして自動起動
- `host`/`port` を明示（デフォルト値: 127.0.0.1:11434）
- `oterm` パッケージを追加（TUIチャットクライアント）
- `acceleration` はコメントアウト（必要に応じて有効化）

### fish/conf.d/abbr.fish
- `o` → `ollama`
- `ol` → `ollama list`
- `ops` → `ollama ps`
- `or` → `ollama run`
- `op` → `ollama pull`

## 確認
- `nix flake check` 通過済み