### PR TITLE
Add `devShells` with default, nix, and editors shells to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -281,13 +281,11 @@
               name = "dotfiles-editors";
               packages = with pkgs; [
                 stylua
-                lua-language-server
                 nodejs_24
               ];
               shellHook = ''
                 echo "[devShell:editors]"
                 stylua --version
-                lua-language-server --version
                 node --version
               '';
             };

--- a/flake.nix
+++ b/flake.nix
@@ -245,6 +245,54 @@
           '';
         in
         {
+          devShells = {
+            default = pkgs.mkShell {
+              name = "dotfiles-default";
+              packages = with pkgs; [
+                git
+                just
+              ];
+              shellHook = ''
+                echo "[devShell:default]"
+                git --version
+                just --version
+              '';
+            };
+
+            nix = pkgs.mkShell {
+              name = "dotfiles-nix";
+              packages = with pkgs; [
+                nixfmt-rfc-style
+                statix
+                deadnix
+                nil
+                nixd
+              ];
+              shellHook = ''
+                echo "[devShell:nix]"
+                nix --version
+                nixfmt --version
+                statix --version
+                deadnix --version
+              '';
+            };
+
+            editors = pkgs.mkShell {
+              name = "dotfiles-editors";
+              packages = with pkgs; [
+                stylua
+                lua-language-server
+                nodejs_24
+              ];
+              shellHook = ''
+                echo "[devShell:editors]"
+                stylua --version
+                lua-language-server --version
+                node --version
+              '';
+            };
+          };
+
           apps = {
             # nix run .#switch
             switch = {


### PR DESCRIPTION
### Motivation

- Provide reproducible development shells in the flake so contributors can quickly enter consistent environments for general tasks, Nix tooling, and editor/tooling work. 
- Surface quick runtime checks of installed tooling versions on shell entry to aid debugging and onboarding. 

### Description

- Add a top-level `devShells` attribute with three shells defined using `pkgs.mkShell`: `default`, `nix`, and `editors`.
- `devShells.default` installs `git` and `just` and prints their versions in a `shellHook` via `git --version` and `just --version`.
- `devShells.nix` installs `nixfmt-rfc-style`, `statix`, `deadnix`, `nil`, and `nixd` and prints `nix`, `nixfmt`, `statix`, and `deadnix` versions in its `shellHook`.
- `devShells.editors` installs `stylua`, `lua-language-server`, and `nodejs_24` and prints `stylua`, `lua-language-server`, and `node` versions in its `shellHook`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c59ada7f4832782ab87472c7dc0c8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added three new preconfigured development environments featuring different tool sets for various development tasks and improved local setup workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nazozokc/dotfiles/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->