### PR TITLE
Add reusable Nix CI workflow and switch existing Nix jobs to use it

### DIFF
--- a/.github/workflows/_nix-ci.yml
+++ b/.github/workflows/_nix-ci.yml
@@ -1,0 +1,27 @@
+name: "Reusable: Nix CI job"
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
+      timeout-minutes:
+        required: false
+        type: number
+        default: 10
+      run-command:
+        required: true
+        type: string
+
+jobs:
+  run:
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - name: Run command
+        run: ${{ inputs.run-command }}

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - ".github/workflows/**"
       - ".github/actionlint.yaml"
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,10 +18,7 @@ concurrency:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - name: actionlint
-        run: nix shell nixpkgs#actionlint --command actionlint
+    uses: ./.github/workflows/_nix-ci.yml
+    with:
+      run-command: nix shell nixpkgs#actionlint --command actionlint
+      timeout-minutes: 10

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -7,6 +7,7 @@ on:
       - "flake.nix"
       - "flake.lock"
       - ".github/workflows/flake-check.yml"
+      - ".github/workflows/_nix-ci.yml"
   pull_request:
 
 concurrency:
@@ -15,10 +16,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
-      - run: nix flake check --no-build
+    uses: ./.github/workflows/_nix-ci.yml
+    with:
+      run-command: nix flake check --no-build
+      timeout-minutes: 10

--- a/.github/workflows/treefmt.yml
+++ b/.github/workflows/treefmt.yml
@@ -12,6 +12,7 @@ on:
       - "**/*.yml"
       - "**/*.ts"
       - ".github/workflows/treefmt.yml"
+      - ".github/workflows/_nix-ci.yml"
   push:
     paths:
       - "**/*.nix"
@@ -24,6 +25,7 @@ on:
       - "**/*.yml"
       - "**/*.ts"
       - ".github/workflows/treefmt.yml"
+      - ".github/workflows/_nix-ci.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,11 +33,7 @@ concurrency:
 
 jobs:
   treefmt:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
-      - name: treefmt check
-        run: nix fmt -- --ci
+    uses: ./.github/workflows/_nix-ci.yml
+    with:
+      run-command: nix fmt -- --ci
+      timeout-minutes: 10


### PR DESCRIPTION
### Motivation

- Reduce duplication across Nix-based GitHub Actions by providing a single reusable job for installing Nix, enabling the cache, and running an arbitrary command via `run-command`.
- Centralize timeout and runner configuration to make workflow updates consistent and easier to maintain.
- Make `actionlint` runnable on a schedule and via `workflow_dispatch`.

### Description

- Add a new reusable workflow `./github/workflows/_nix-ci.yml` that accepts `runs-on`, `timeout-minutes`, and `run-command` inputs and performs `actions/checkout`, `DeterminateSystems/nix-installer-action@v22`, `DeterminateSystems/magic-nix-cache-action@v13`, and then runs the provided `run-command`.
- Update `actionlint.yml`, `flake-check.yml`, and `treefmt.yml` to use the reusable workflow via `uses: ./.github/workflows/_nix-ci.yml` and pass `run-command` and `timeout-minutes` instead of duplicating setup steps.
- Add `schedule` and `workflow_dispatch` triggers to `actionlint.yml` and include `._nix-ci.yml` in the path filters for `flake-check.yml` and `treefmt.yml` so changes to the reusable workflow affect dependent jobs.

### Testing

- No automated tests were executed as part of this PR since the change only updates CI workflow configuration files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5fae755883279b378d0e67ad3aa6)