### PR TITLE
Add multi-OS CI for flake & fmt, sops secrets support, and docs

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,4 +1,3 @@
-# .github/workflows/flake-check.yml
 name: Nix Flake Check
 on:
   push:
@@ -6,6 +5,7 @@ on:
     paths:
       - "flake.nix"
       - "flake.lock"
+      - "nix/**"
       - ".github/workflows/flake-check.yml"
       - ".github/workflows/_nix-ci.yml"
   pull_request:
@@ -16,7 +16,27 @@ concurrency:
 
 jobs:
   check:
+    name: flake-check (${{ matrix.os }})
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
     uses: ./.github/workflows/_nix-ci.yml
     with:
-      run-command: nix flake check --no-build
+      runs-on: ${{ matrix.os }}
+      run-command: nix flake check
+      timeout-minutes: 20
+
+  fmt-check:
+    name: treefmt-ci (${{ matrix.os }})
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    uses: ./.github/workflows/_nix-ci.yml
+    with:
+      runs-on: ${{ matrix.os }}
+      run-command: nix fmt -- --ci
       timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ nix fmt -- --ci
   2. 変更PRで `nix flake check` と `nix run .#build` を通過。
   3. 既存dotfilesリンク・シェル起動・主要CLI（git, gh, nvim）動作確認を記録。
 
-
 # Activity
 
 ![Alt](https://repobeats.axiom.co/api/embed/c4db566c918002010974abbbcc1ee5150bed51da.svg "Repobeats analytics image")

--- a/README.md
+++ b/README.md
@@ -118,6 +118,36 @@ nix run .#update
 - OS本体やカーネルは pacman（Linux）や macOS 標準管理に任せる
 - Home Manager によるリンクや設定は既存の dotfiles を上書きする場合があります
 
+## 運用ルール（品質ゲート）
+
+- PR では **Nix Flake Check**（`nix flake check`）と **treefmt check**（`nix fmt -- --ci`）を必須とします。
+- ローカルでも PR 前に次を実行してください。
+
+```bash
+nix flake check
+nix fmt -- --ci
+```
+
+## シークレット管理（sops-nix）
+
+- シークレットは `secrets/common.yaml` を **sops で暗号化**して管理します。
+- 展開先（Linux / WSL）は以下です。
+  - `api/github_token` → `~/.config/secrets/github_token`
+  - `api/openai_api_key` → `~/.config/secrets/openai_api_key`
+  - `api/anthropic_api_key` → `~/.config/secrets/anthropic_api_key`
+- 鍵は `~/.config/sops/age/keys.txt` を使用します。
+- `secrets/common.yaml` が存在しない場合、secret は読み込まれません（CIの非復号チェックを壊さないため）。
+
+## home.stateVersion ポリシー
+
+- 現在値は `nix/shared.nix` の `home.stateVersion = "26.05";`。
+- 互換性維持のため、**通常運用で上げない**。
+- 上げるのは以下を満たす場合のみ。
+  1. Home Manager / nixpkgs 更新で新規 stateVersion が必要。
+  2. 変更PRで `nix flake check` と `nix run .#build` を通過。
+  3. 既存dotfilesリンク・シェル起動・主要CLI（git, gh, nvim）動作確認を記録。
+
+
 # Activity
 
 ![Alt](https://repobeats.axiom.co/api/embed/c4db566c918002010974abbbcc1ee5150bed51da.svg "Repobeats analytics image")

--- a/nix/README.md
+++ b/nix/README.md
@@ -127,3 +127,33 @@ nix run .#update
 
 **あまり参照はないが参考にはなりそう**
 <https://github.com/ntsk/dotfiles>
+
+## 運用ポリシー（追加）
+
+### CI品質ゲート
+
+- PR の必須チェックは以下。
+  - `nix flake check`
+  - `nix fmt -- --ci`
+- 上記は Linux / macOS の両方で実行する。
+
+### sops-nix シークレット運用
+
+- 暗号化ファイルは `secrets/common.yaml` を使用する。
+- home-manager の展開先:
+  - `api/github_token` → `~/.config/secrets/github_token`
+  - `api/openai_api_key` → `~/.config/secrets/openai_api_key`
+  - `api/anthropic_api_key` → `~/.config/secrets/anthropic_api_key`
+- AGE鍵は `~/.config/sops/age/keys.txt`。
+- `secrets/common.yaml` がない環境では secret を読まない（復号不要のCIを壊さないため）。
+
+### home.stateVersion 更新ルール
+
+- 定義位置: `nix/shared.nix`
+- 現在値: `26.05`
+- 互換性優先のため普段は固定する。
+- 更新時は以下を必須にする。
+  1. 変更理由をPR本文に明記
+  2. `nix flake check` 通過
+  3. `nix run .#build` 通過
+  4. dotfilesリンク・主要CLI起動確認結果をPRに記録

--- a/nix/modules/home-manager/program/sops/default.nix
+++ b/nix/modules/home-manager/program/sops/default.nix
@@ -7,6 +7,8 @@
 
 let
   homeDir = config.home.homeDirectory;
+  secretsFile = ../../../../secrets/common.yaml;
+  hasSecretsFile = builtins.pathExists secretsFile;
 in
 {
   sops = lib.mkIf pkgs.stdenv.isLinux {
@@ -15,6 +17,26 @@ in
       generateKey = false;
     };
 
-    secrets = { };
+    # secrets/common.yaml がある時だけ読み込む
+    defaultSopsFile = lib.mkIf hasSecretsFile secretsFile;
+
+    # 各 secret は Linux / WSL 共通で ~/.config/secrets に展開
+    # NOTE: 実値は secrets/common.yaml を sops で暗号化して管理する
+    secrets = lib.optionalAttrs hasSecretsFile {
+      "api/github_token" = {
+        path = "${homeDir}/.config/secrets/github_token";
+        mode = "0400";
+      };
+
+      "api/openai_api_key" = {
+        path = "${homeDir}/.config/secrets/openai_api_key";
+        mode = "0400";
+      };
+
+      "api/anthropic_api_key" = {
+        path = "${homeDir}/.config/secrets/anthropic_api_key";
+        mode = "0400";
+      };
+    };
   };
 }

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,20 @@
+# secrets/common.yaml のフォーマット
+
+このディレクトリは sops-nix 用の暗号化シークレット置き場。
+
+`common.yaml` に次のキーを入れる。
+
+```yaml
+api:
+  github_token: ghp_xxx
+  openai_api_key: sk-xxx
+  anthropic_api_key: sk-ant-xxx
+```
+
+作成例:
+
+```bash
+sops secrets/common.yaml
+```
+
+> `common.yaml` は平文でコミットしない。必ず sops で暗号化した状態で管理する。


### PR DESCRIPTION
### Motivation

- Enforce Nix flake checks and tree formatting as PR quality gates across both Linux and macOS.
- Document secret management with `sops` and standardize where secrets are deployed under `~/.config/secrets`.
- Make `sops` integration robust so missing `secrets/common.yaml` does not break CI or local usage.

### Description

- Update `.github/workflows/flake-check.yml` to run `nix flake check` in a two-OS matrix and add a `fmt-check` job running `nix fmt -- --ci`, with `runs-on` and timeouts configured.
- Add CI and operational guidance to `README.md` and `nix/README.md`, including the required local commands `nix flake check` and `nix fmt -- --ci`, `sops` usage, and `home.stateVersion` policy.
- Change `nix/modules/home-manager/program/sops/default.nix` to conditionally use `secrets/common.yaml` via `defaultSopsFile`, set `age.keyFile`, and map secrets to `~/.config/secrets/*` with proper file modes only when the secrets file exists.
- Add `secrets/README.md` describing the `secrets/common.yaml` format and how to create it with `sops`.

### Testing

- No automated tests were executed as part of this change; CI is configured to run on PR creation.
- The new workflow will run `nix flake check` and `nix fmt -- --ci` on both `ubuntu-latest` and `macos-latest` when the PR is opened.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d76fbd6748327beacb6e47041a043)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CI/CD pipeline with format checking across Linux and macOS platforms.
  * Implemented secrets management with conditional loading and encryption.

* **Documentation**
  * Added operational guidelines covering quality gates, secrets handling, and state version management.
  * Added secrets directory documentation with required configuration structure.

* **Chores**
  * Expanded workflow triggers to include Nix configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nazozokc/dotfiles/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->