### PR TITLE
Refactor home-manager module composition; enhance direnv and sops configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,15 @@
         system:
         let
           pkgs = pkgsFor system;
+          commonHomeModules = [
+            nix-index-database.homeModules.nix-index
+            sops-nix.homeManagerModules.sops
+            ./nix/shared.nix
+            ./nix/modules/home-manager/dotfiles-link.nix
+            ./nix/modules/home-manager/program/nvim/default.nix
+            agent-skills-nix.homeManagerModules.default
+            ./nix/modules/home-manager/agent-skills.nix
+          ];
         in
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
@@ -143,17 +152,12 @@
             inherit username;
             dotfilesDir = self.outPath;
           };
-          modules = [
-            nix-index-database.homeModules.nix-index
-            sops-nix.homeManagerModules.sops
-            ./nix/shared.nix
-            (import ./nix/modules/home-manager/tools-read.nix { inherit pkgs; })
-            ./nix/modules/linux/system.nix
-            ./nix/modules/home-manager/dotfiles-link.nix
-            ./nix/modules/home-manager/program/nvim/default.nix
-            agent-skills-nix.homeManagerModules.default
-            ./nix/modules/home-manager/agent-skills.nix
-          ];
+          modules =
+            commonHomeModules
+            ++ [
+              (import ./nix/modules/home-manager/tools-read.nix { inherit pkgs; })
+              ./nix/modules/linux/system.nix
+            ];
         };
 
       # WSL 向け home-manager 設定を生成するヘルパー
@@ -161,6 +165,15 @@
         system:
         let
           pkgs = pkgsFor system;
+          commonHomeModules = [
+            nix-index-database.homeModules.nix-index
+            sops-nix.homeManagerModules.sops
+            ./nix/shared.nix
+            ./nix/modules/home-manager/dotfiles-link.nix
+            ./nix/modules/home-manager/program/nvim/default.nix
+            agent-skills-nix.homeManagerModules.default
+            ./nix/modules/home-manager/agent-skills.nix
+          ];
         in
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
@@ -168,17 +181,12 @@
             inherit username;
             dotfilesDir = self.outPath;
           };
-          modules = [
-            nix-index-database.homeModules.nix-index
-            sops-nix.homeManagerModules.sops
-            ./nix/shared.nix
-            (import ./nix/modules/home-manager/tools-read-wsl.nix { inherit pkgs; })
-            ./nix/modules/wsl/system.nix
-            ./nix/modules/home-manager/dotfiles-link.nix
-            ./nix/modules/home-manager/program/nvim/default.nix
-            agent-skills-nix.homeManagerModules.default
-            ./nix/modules/home-manager/agent-skills.nix
-          ];
+          modules =
+            commonHomeModules
+            ++ [
+              (import ./nix/modules/home-manager/tools-read-wsl.nix { inherit pkgs; })
+              ./nix/modules/wsl/system.nix
+            ];
         };
 
     in

--- a/flake.nix
+++ b/flake.nix
@@ -152,12 +152,10 @@
             inherit username;
             dotfilesDir = self.outPath;
           };
-          modules =
-            commonHomeModules
-            ++ [
-              (import ./nix/modules/home-manager/tools-read.nix { inherit pkgs; })
-              ./nix/modules/linux/system.nix
-            ];
+          modules = commonHomeModules ++ [
+            (import ./nix/modules/home-manager/tools-read.nix { inherit pkgs; })
+            ./nix/modules/linux/system.nix
+          ];
         };
 
       # WSL 向け home-manager 設定を生成するヘルパー
@@ -181,12 +179,10 @@
             inherit username;
             dotfilesDir = self.outPath;
           };
-          modules =
-            commonHomeModules
-            ++ [
-              (import ./nix/modules/home-manager/tools-read-wsl.nix { inherit pkgs; })
-              ./nix/modules/wsl/system.nix
-            ];
+          modules = commonHomeModules ++ [
+            (import ./nix/modules/home-manager/tools-read-wsl.nix { inherit pkgs; })
+            ./nix/modules/wsl/system.nix
+          ];
         };
 
     in

--- a/nix/modules/home-manager/program/direnv.nix
+++ b/nix/modules/home-manager/program/direnv.nix
@@ -49,11 +49,4 @@
     '';
   };
 
-  home.file.".config/direnv/direnvrc".text = ''
-    # Prefer flake-based environments in every project.
-    source_up_if_exists .envrc
-    if [[ -f flake.nix ]]; then
-      use flake
-    fi
-  '';
 }

--- a/nix/modules/home-manager/program/direnv.nix
+++ b/nix/modules/home-manager/program/direnv.nix
@@ -2,6 +2,9 @@
 {
   programs.direnv = {
     enable = true;
+    enableBashIntegration = true;
+    enableFishIntegration = true;
+    enableZshIntegration = true;
 
     nix-direnv.enable = true;
 
@@ -12,6 +15,7 @@
         load_dotenv = true;
         strict_env = false;
         warn_timeout = "5m";
+        disable_stdin = true;
       };
     };
 
@@ -44,4 +48,12 @@
       }
     '';
   };
+
+  home.file.".config/direnv/direnvrc".text = ''
+    # Prefer flake-based environments in every project.
+    source_up_if_exists .envrc
+    if [[ -f flake.nix ]]; then
+      use flake
+    fi
+  '';
 }

--- a/nix/modules/home-manager/program/sops/default.nix
+++ b/nix/modules/home-manager/program/sops/default.nix
@@ -11,6 +11,15 @@ let
   hasSecretsFile = builtins.pathExists secretsFile;
 in
 {
+  home.file.".config/secrets/.keep".text = "";
+
+  home.sessionVariables = {
+    SOPS_AGE_KEY_FILE = "${homeDir}/.config/sops/age/keys.txt";
+    GITHUB_TOKEN_PATH = "${homeDir}/.config/secrets/github_token";
+    OPENAI_API_KEY_PATH = "${homeDir}/.config/secrets/openai_api_key";
+    ANTHROPIC_API_KEY_PATH = "${homeDir}/.config/secrets/anthropic_api_key";
+  };
+
   sops = lib.mkIf pkgs.stdenv.isLinux {
     age = {
       keyFile = "${homeDir}/.config/sops/age/keys.txt";


### PR DESCRIPTION
### Motivation

- Reduce duplication by extracting shared home-manager modules for Linux and WSL and make platform-specific modules appended cleanly.
- Improve developer experience by enabling shell integrations and safer defaults for `direnv` and auto-prefer flake-based environments.
- Ensure secrets and sops key paths are available in the user session and ensure the secrets directory is present.

### Description

- Extracted `commonHomeModules` and applied it to both `mkLinuxHomeConfig` and `mkWSLHomeConfig`, and changed how platform-specific modules are appended in `flake.nix` to avoid duplication.  
- Reworked `mkWSLHomeConfig` ordering so WSL-specific modules (`tools-read-wsl.nix` and `./nix/modules/wsl/system.nix`) are appended to the common modules.  
- Enabled `programs.direnv` integrations for Bash, Fish, and Zsh, set `disable_stdin = true`, and added helper stdlib functions to hide and show environment diffs and to auto-load flake/shell environments in `nix/modules/home-manager/program/direnv.nix`.  
- Added a `home.file` at `.config/direnv/direnvrc` to prefer flake-based environments and source upstream `.envrc` files.  
- Extended the `sops` home-manager module in `nix/modules/home-manager/program/sops/default.nix` to create `.config/secrets/.keep`, expose session variables for key and token paths (e.g. `SOPS_AGE_KEY_FILE`, `GITHUB_TOKEN_PATH`, `OPENAI_API_KEY_PATH`, `ANTHROPIC_API_KEY_PATH`), and keep the `age` key and secrets mapping for Linux/WSL users.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d988e12fc8327912cadee66abd3f6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled direnv shell integrations (Bash, Fish, Zsh) with automatic flake environment detection and preference.
  * Added secrets management environment variable configuration for streamlined credential access.

* **Chores**
  * Refactored module structure for improved configuration organization.
  * Initialized secrets directory structure for development environment setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nazozokc/dotfiles/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->