### PR TITLE
docs(nix): fix stale macOS package/module references

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -34,9 +34,9 @@
 - unzip, zip (アーカイブ)
 - nmap (ネットワーク)
 
-### macOS専用パッケージ (`nix/modules/home-manager/darwin.nix`)
+### macOS専用パッケージ (`nix/modules/home-manager/packages/gui.nix`)
 
-- coreutils, gnused, gawk, inetutils (基本コマンド)
+- raycast (GUIランチャー)
 
 ### macOSシステムパッケージ (`nix/modules/darwin/system.nix`)
 
@@ -50,7 +50,6 @@ nix/
 │   ├── darwin/
 │   │   └── system.nix
 │   ├── home-manager/
-│   │   ├── darwin.nix
 │   │   ├── dotfiles-link.nix
 │   │   ├── tools-read.nix
 │   │   ├── tools-read-wsl.nix


### PR DESCRIPTION
### Motivation
- `nix/README.md` が実際のモジュール構成とズレており、存在しない `nix/modules/home-manager/darwin.nix` を参照していたため誤解を招く状態だった。 

### Description
- `nix/README.md` の macOS 専用パッケージ参照を `nix/modules/home-manager/packages/gui.nix` に差し替え、説明を `raycast` に更新し、モジュール構成ツリーから存在しない `nix/modules/home-manager/darwin.nix` の行を削除した。 

### Testing
- `nix flake check` を実行しようとしたが、この環境に `nix` コマンドが無いため検証できなかった（`/bin/bash: nix: command not found`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dafd5e9948327a7e8f64b32fcfd8e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated macOS package listings in configuration documentation
  * Refreshed module structure diagram to align with current setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nazozokc/dotfiles/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->