### PR TITLE
fix: nix-wezterm on linux desktop to error

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,6 +192,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gh-brag": {
       "flake": false,
       "locked": {
@@ -360,6 +378,27 @@
         "type": "github"
       }
     },
+    "nixGL": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762090880,
+        "narHash": "sha256-fbRQzIGPkjZa83MowjbD2ALaJf9y6KMDdJBQMKFeY/8=",
+        "owner": "guibou",
+        "repo": "nixGL",
+        "rev": "b6105297e6f0cd041670c3e8628394d4ee247ed5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "guibou",
+        "repo": "nixGL",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780365719,
@@ -448,6 +487,7 @@
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
         "nix-index-database": "nix-index-database",
+        "nixGL": "nixGL",
         "nixpkgs": "nixpkgs_2",
         "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix_3"
@@ -474,6 +514,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,12 @@
       url = "github:mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # GPU ライブラリラッパー (非 NixOS で Nix GUI アプリを動かす)
+    nixGL = {
+      url = "github:guibou/nixGL";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   # ---------------------------------------------------------------------------
@@ -102,6 +108,7 @@
       treefmt-nix,
       agent-skills-nix,
       sops-nix,
+      nixGL,
       ...
     }:
     let
@@ -148,6 +155,7 @@
           extraSpecialArgs = {
             inherit pkgs username;
             dotfilesDir = self.outPath;
+            nixGLPackages = nixGL.packages.${system};
           };
           modules = commonHomeModules ++ [
             ./nix/modules/home

--- a/nix/modules/home/packages/gui/default.nix
+++ b/nix/modules/home/packages/gui/default.nix
@@ -2,7 +2,6 @@
 
 with pkgs;
 [
-  wezterm
   audacity
   vscode
   zed

--- a/nix/modules/linux/default.nix
+++ b/nix/modules/linux/default.nix
@@ -2,8 +2,42 @@
 # Linux モジュールのエントリーポイント
 # 各責務を packages.nix / programs.nix に分離
 {
+  config,
+  pkgs,
+  nixGLPackages,
+  ...
+}:
+
+let
+  # Wrapped version of wezterm with nixGL so it can find system GPU libraries
+  # (libEGL.so etc.) on non-NixOS Linux (Arch Linux).
+  wezterm-wrapped = config.lib.nixGL.wrap pkgs.wezterm;
+in
+{
   imports = [
     ./packages.nix
     ./system.nix
+  ];
+
+  # ---------------------------------------------------------------------------
+  # Generic Linux support – enables XDG paths, nixGL, etc. for non-NixOS distros
+  # ---------------------------------------------------------------------------
+  targets.genericLinux = {
+    enable = true;
+    nixGL = {
+      packages = nixGLPackages;
+      # Provide nixGLMesa script for ad-hoc wrapping of other GPU apps
+      installScripts = [ "mesa" ];
+    };
+  };
+
+  # ---------------------------------------------------------------------------
+  # wezterm: nixGL-wrapped version
+  # ---------------------------------------------------------------------------
+  # On non-NixOS, the Nix-packaged wezterm can't find system libEGL.so because
+  # its RUNPATH only contains Nix store paths. nixGL bridges the gap.
+  # wezterm は gui/default.nix から外し、Linux でのみ wrapped 版を入れる。
+  home.packages = [
+    wezterm-wrapped
   ];
 }

--- a/nix/modules/macos/darwin-home.nix
+++ b/nix/modules/macos/darwin-home.nix
@@ -17,5 +17,8 @@
   home.packages = with pkgs; [
     # フォント
     fontconfig
+
+    # GPU ラッパーが不要なプラットフォームでは素の wezterm を使う
+    wezterm
   ];
 }

--- a/wezterm/config/session.lua
+++ b/wezterm/config/session.lua
@@ -18,8 +18,8 @@ function M.apply(config)
 	end)
 end
 
--- Register gui-startup ONCE per process (wezterm.once prevents duplicates on config reload).
-wezterm.once("gui-startup", function(cmd)
+-- Subscribe to gui-startup (fires only once per process; safe on config reload).
+wezterm.on("gui-startup", function(cmd)
 	local saved = wezterm.state(STATE_KEY)
 	if saved and saved ~= "" and saved ~= "default" then
 		cmd = cmd or {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU library support for terminal application on Linux systems.
  * Platform-specific package availability: Raycast for macOS; Ghostty, Tor Browser, and Vicinae for Linux; Spotify, Discord, and Google Chrome for both.

* **Chores**
  * Updated package management infrastructure for multi-platform configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->